### PR TITLE
Fix spaces yeoman generating spaces in app name

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -5,6 +5,7 @@ var yosay = require('yosay');
 var npm = require('npm');
 var gitConfig = require('git-config');
 var camelcase = require('lodash.camelcase');
+var kebabcase = require('lodash.kebabcase');
 
 module.exports = yeoman.generators.Base.extend({
   initializing: function () {
@@ -30,7 +31,7 @@ module.exports = yeoman.generators.Base.extend({
         type: 'input',
         name: 'repo',
         message: 'What is your repo/projects name?',
-        default: this.appname
+        default: kebabcase(this.appname)
       }, {
         type: 'input',
         name: 'description',

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "fullname": "^1.1.0",
     "git-config": "0.0.6",
     "lodash.camelcase": "^3.0.1",
+    "lodash.kebabcase": "^3.0.1",
     "npm": "*",
     "yeoman-generator": "^0.18.0",
     "yosay": "^0.3.0"


### PR DESCRIPTION
Yeoman converts a project in folder `foo-bar` to `foo bar`. This just changes it right back.

Theres probably a better way to do this - but its broken atm (just tested)
